### PR TITLE
Volume Slider Styling + Replay Control

### DIFF
--- a/src/components/control-bar/ForwardReplayControl.js
+++ b/src/components/control-bar/ForwardReplayControl.js
@@ -4,14 +4,14 @@ import React, { Component } from 'react';
 const propTypes = {
   actions: PropTypes.object,
   className: PropTypes.string,
-  seconds: PropTypes.oneOf([5, 10, 30])
+  seconds: PropTypes.oneOf([5, 10, 15, 30])
 };
 
 const defaultProps = {
-  seconds: 10
+  seconds: 15
 };
 
-export default (mode) => {
+export default mode => {
   class ForwardReplayControl extends Component {
     constructor(props, context) {
       super(props, context);
@@ -44,7 +44,7 @@ export default (mode) => {
       }
       return (
         <button
-          ref={(c) => {
+          ref={c => {
             this.button = c;
           }}
           className={classNames.join(' ')}

--- a/src/components/control-bar/VolumeMenuButton.js
+++ b/src/components/control-bar/VolumeMenuButton.js
@@ -12,7 +12,7 @@ const propTypes = {
   vertical: PropTypes.bool,
   className: PropTypes.string,
   alwaysShowVolume: PropTypes.bool,
-  children: PropTypes.any
+  children: PropTypes.node
 };
 
 const defaultProps = {

--- a/src/components/control-bar/VolumeMenuButton.js
+++ b/src/components/control-bar/VolumeMenuButton.js
@@ -4,13 +4,15 @@ import classNames from 'classnames';
 
 import PopupButton from '../popup/PopupButton';
 import VolumeBar from '../volume-control/VolumeBar';
+import { mergeAndSortChildren } from '../../utils';
 
 const propTypes = {
   player: PropTypes.object,
   actions: PropTypes.object,
   vertical: PropTypes.bool,
   className: PropTypes.string,
-  alwaysShowVolume: PropTypes.bool
+  alwaysShowVolume: PropTypes.bool,
+  children: PropTypes.any
 };
 
 const defaultProps = {
@@ -28,6 +30,7 @@ class VolumeMenuButton extends Component {
     this.handleClick = this.handleClick.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
+    this.getDefaultChildren = this.getDefaultChildren.bind(this);
   }
 
   get volumeLevel() {
@@ -62,11 +65,11 @@ class VolumeMenuButton extends Component {
     });
   }
 
-  render() {
+  getDefaultChildren() {
     const { vertical, player, className } = this.props;
     const inline = !vertical;
     const level = this.volumeLevel;
-    return (
+    return [
       <PopupButton
         className={classNames(
           className,
@@ -87,6 +90,7 @@ class VolumeMenuButton extends Component {
         )}
         onClick={this.handleClick}
         inline={inline}
+        player={player}
       >
         <VolumeBar
           onFocus={this.handleFocus}
@@ -94,6 +98,46 @@ class VolumeMenuButton extends Component {
           {...this.props}
         />
       </PopupButton>
+    ];
+  }
+
+  getChildren() {
+    const children = React.Children.toArray(this.props.children);
+    const defaultChildren = this.getDefaultChildren();
+    const { className, ...parentProps } = this.props; // remove className
+    console.log('parentProps', parentProps);
+    return mergeAndSortChildren(defaultChildren, children, parentProps);
+  }
+
+  render() {
+    const children = this.getChildren();
+
+    return (
+      <React.Fragment>{children}</React.Fragment>
+
+      // <PopupButton
+      //   className={classNames(
+      //     className,
+      //     {
+      //       'video-react-volume-menu-button-vertical': vertical,
+      //       'video-react-volume-menu-button-horizontal': !vertical,
+      //       'video-react-vol-muted': player.muted,
+      //       'video-react-vol-0': level === 0 && !player.muted,
+      //       'video-react-vol-1': level === 1,
+      //       'video-react-vol-2': level === 2,
+      //       'video-react-vol-3': level === 3,
+      //       'video-react-slider-active':
+      //         this.props.alwaysShowVolume || this.state.active,
+      //       'video-react-lock-showing':
+      //         this.props.alwaysShowVolume || this.state.active
+      //     },
+      //     'video-react-volume-menu-button'
+      //   )}
+      //   onClick={this.handleClick}
+      //   inline={inline}
+      // >
+      //   {children}
+      // </PopupButton>
     );
   }
 }

--- a/src/components/control-bar/VolumeMenuButton.js
+++ b/src/components/control-bar/VolumeMenuButton.js
@@ -66,10 +66,30 @@ class VolumeMenuButton extends Component {
   }
 
   getDefaultChildren() {
+    return [
+      <VolumeBar
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur}
+        {...this.props}
+      />
+    ];
+  }
+
+  getChildren() {
+    const children = React.Children.toArray(this.props.children);
+    const defaultChildren = this.getDefaultChildren();
+    const { className, ...parentProps } = this.props; // remove className
+    return mergeAndSortChildren(defaultChildren, children, parentProps);
+  }
+
+  render() {
     const { vertical, player, className } = this.props;
     const inline = !vertical;
     const level = this.volumeLevel;
-    return [
+
+    const children = this.getChildren();
+
+    return (
       <PopupButton
         className={classNames(
           className,
@@ -90,54 +110,9 @@ class VolumeMenuButton extends Component {
         )}
         onClick={this.handleClick}
         inline={inline}
-        player={player}
       >
-        <VolumeBar
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-          {...this.props}
-        />
+        {children}
       </PopupButton>
-    ];
-  }
-
-  getChildren() {
-    const children = React.Children.toArray(this.props.children);
-    const defaultChildren = this.getDefaultChildren();
-    const { className, ...parentProps } = this.props; // remove className
-    console.log('parentProps', parentProps);
-    return mergeAndSortChildren(defaultChildren, children, parentProps);
-  }
-
-  render() {
-    const children = this.getChildren();
-
-    return (
-      <React.Fragment>{children}</React.Fragment>
-
-      // <PopupButton
-      //   className={classNames(
-      //     className,
-      //     {
-      //       'video-react-volume-menu-button-vertical': vertical,
-      //       'video-react-volume-menu-button-horizontal': !vertical,
-      //       'video-react-vol-muted': player.muted,
-      //       'video-react-vol-0': level === 0 && !player.muted,
-      //       'video-react-vol-1': level === 1,
-      //       'video-react-vol-2': level === 2,
-      //       'video-react-vol-3': level === 3,
-      //       'video-react-slider-active':
-      //         this.props.alwaysShowVolume || this.state.active,
-      //       'video-react-lock-showing':
-      //         this.props.alwaysShowVolume || this.state.active
-      //     },
-      //     'video-react-volume-menu-button'
-      //   )}
-      //   onClick={this.handleClick}
-      //   inline={inline}
-      // >
-      //   {children}
-      // </PopupButton>
     );
   }
 }

--- a/src/components/volume-control/VolumeBar.js
+++ b/src/components/volume-control/VolumeBar.js
@@ -94,11 +94,13 @@ class VolumeBar extends Component {
 
   render() {
     const { player, className } = this.props;
+    console.log('vol bar props', this.props);
+    console.log('player', player);
 
     const volume = (player.volume * 100).toFixed(2);
     return (
       <Slider
-        ref={(c) => {
+        ref={c => {
           this.slider = c;
         }}
         label="volume level"

--- a/src/components/volume-control/VolumeBar.js
+++ b/src/components/volume-control/VolumeBar.js
@@ -98,13 +98,6 @@ class VolumeBar extends Component {
 
     const volume = (player.volume * 100).toFixed(2);
 
-    // volume slider -- render slider with volume level and default props
-    // change things in .scss
-    // change level manually
-    // get rid of ::before element
-    // background color of slider
-    // height of slider
-    // background of slider (style popupbutton in volumemenubutton maybe?)
     return (
       <Slider
         ref={c => {

--- a/src/components/volume-control/VolumeBar.js
+++ b/src/components/volume-control/VolumeBar.js
@@ -93,11 +93,18 @@ class VolumeBar extends Component {
   }
 
   render() {
-    const { player, className } = this.props;
-    console.log('vol bar props', this.props);
-    console.log('player', player);
+    const { className, ...parentProps } = this.props; // remove className
+    const { player } = this.props;
 
     const volume = (player.volume * 100).toFixed(2);
+
+    // volume slider -- render slider with volume level and default props
+    // change things in .scss
+    // change level manually
+    // get rid of ::before element
+    // background color of slider
+    // height of slider
+    // background of slider (style popupbutton in volumemenubutton maybe?)
     return (
       <Slider
         ref={c => {
@@ -122,7 +129,7 @@ class VolumeBar extends Component {
           'video-react-volume-bar video-react-slider-bar'
         )}
       >
-        <VolumeLevel {...this.props} />
+        <VolumeLevel {...parentProps} />
       </Slider>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -28,9 +28,6 @@ import DurationDisplay from './components/time-controls/DurationDisplay';
 import TimeDivider from './components/time-controls/TimeDivider';
 
 import VolumeBar from './components/volume-control/VolumeBar';
-import VolumeLevel from './components/volume-control/VolumeLevel';
-
-import PopupButton from './components/popup/PopupButton';
 
 import MenuButton from './components/menu/MenuButton';
 
@@ -63,8 +60,6 @@ export {
   TimeDivider,
   VolumeMenuButton,
   VolumeBar,
-  VolumeLevel,
-  PopupButton,
   PlaybackRateMenuButton,
   ClosedCaptionButton,
   PlaybackRate,

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,11 @@ import CurrentTimeDisplay from './components/time-controls/CurrentTimeDisplay';
 import DurationDisplay from './components/time-controls/DurationDisplay';
 import TimeDivider from './components/time-controls/TimeDivider';
 
+import VolumeBar from './components/volume-control/VolumeBar';
+import VolumeLevel from './components/volume-control/VolumeLevel';
+
+import PopupButton from './components/popup/PopupButton';
+
 import MenuButton from './components/menu/MenuButton';
 
 import * as playerActions from './actions/player';
@@ -57,6 +62,9 @@ export {
   DurationDisplay,
   TimeDivider,
   VolumeMenuButton,
+  VolumeBar,
+  VolumeLevel,
+  PopupButton,
   PlaybackRateMenuButton,
   ClosedCaptionButton,
   PlaybackRate,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -99,7 +99,6 @@ export function mergeAndSortChildren(
       );
 
       const defaultProps = defaultComponent ? defaultComponent.props : {};
-      console.log(parentProps, defaultProps, element.props);
       const props = {
         ...parentProps, // inherit from parent component
         ...defaultProps, // inherit from default component

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -93,10 +93,13 @@ export function mergeAndSortChildren(
         c => !find(children, component => isTypeEqual(component, c))
       )
     )
-    .map((element) => {
-      const defaultComponent = find(defaultChildren, c => isTypeEqual(c, element));
+    .map(element => {
+      const defaultComponent = find(defaultChildren, c =>
+        isTypeEqual(c, element)
+      );
 
       const defaultProps = defaultComponent ? defaultComponent.props : {};
+      console.log(parentProps, defaultProps, element.props);
       const props = {
         ...parentProps, // inherit from parent component
         ...defaultProps, // inherit from default component
@@ -106,7 +109,8 @@ export function mergeAndSortChildren(
       return e;
     })
     .sort(
-      (a, b) => (a.props.order || defaultOrder) - (b.props.order || defaultOrder)
+      (a, b) =>
+        (a.props.order || defaultOrder) - (b.props.order || defaultOrder)
     );
 }
 

--- a/styles/scss/components/menu/menu-popup.scss
+++ b/styles/scss/components/menu/menu-popup.scss
@@ -2,20 +2,15 @@
   .video-react-menu-button-popup .video-react-menu {
     display: none;
     position: absolute;
-    bottom: 0;
+    bottom: 100%;
     width: 10em;
     left: -3em; // (Width of video-react-menu - width of button) / 2
     height: 0em;
-    margin-bottom: 1.5em;
     border-top-color: rgba($video-react-primary-background-color, $video-react-primary-background-transparency); // Same as ul background
 
     .video-react-menu-content {
       @include background-color-with-alpha($video-react-primary-background-color, $video-react-primary-background-transparency);
-
-      position: absolute;
-      width: 100%;
       bottom: 1.5em; // Same bottom as video-react-menu border-top
-      max-height: 15em;
     }
   }
 

--- a/styles/scss/components/volume.scss
+++ b/styles/scss/components/volume.scss
@@ -45,6 +45,7 @@
 
       .video-react-volume-level {
         height: 100%;
+        width: 100%;
       }
 
     }
@@ -52,41 +53,21 @@
 
   .video-react-volume-level {
     position: absolute;
-    bottom: 0;
     left: 0;
+    bottom: 0;
+    border-radius: inherit;
 
     background-color: $video-react-primary-foreground-color;
-
-    @extend .video-react-icon;
-    @extend .video-react-icon-circle;
-
-    // Volume handle
-    &:before {
-      position: absolute;
-      font-size: 0.9em; // Doing this to match the handle on play progress.
-    }
   }
 
 
 
   .video-react-slider-vertical .video-react-volume-level {
     width: 0.3em;
-
-    // Volume handle
-    &:before {
-      top: -0.5em;
-      left: -0.3em;
-    }
   }
 
   .video-react-slider-horizontal .video-react-volume-level {
     height: 0.3em;
-
-    // Volume handle
-    &:before {
-      top: -0.3em;
-      right: -0.5em;
-    }
   }
 
 
@@ -104,8 +85,11 @@
   }
 
   .video-react-menu-button-popup.video-react-volume-menu-button-vertical .video-react-menu {
-    left: 0.5em;
-    height: 8em;
+    left: 0;
+    height: auto;
+    width: inherit;
+    background-color: inherit;
+    border-radius: 4px 4px 0 0;
   }
   .video-react-menu-button-popup.video-react-volume-menu-button-horizontal .video-react-menu {
     left: -2em;
@@ -120,13 +104,13 @@
     overflow-y: hidden;
   }
 
-  // what if we nix this?
   .video-react-volume-menu-button-vertical:hover .video-react-menu-content,
   .video-react-volume-menu-button-vertical:focus .video-react-menu-content,
   .video-react-volume-menu-button-vertical.video-react-slider-active .video-react-menu-content,
   .video-react-volume-menu-button-vertical .video-react-lock-showing .video-react-menu-content {
-    height: 8em;
-    width: 2.9em;
+    height: auto;
+    width: inherit;
+    background-color: transparent;
   }
 
   .video-react-volume-menu-button-horizontal:hover .video-react-menu-content,

--- a/styles/scss/components/volume.scss
+++ b/styles/scss/components/volume.scss
@@ -120,6 +120,7 @@
     overflow-y: hidden;
   }
 
+  // what if we nix this?
   .video-react-volume-menu-button-vertical:hover .video-react-menu-content,
   .video-react-volume-menu-button-vertical:focus .video-react-menu-content,
   .video-react-volume-menu-button-vertical.video-react-slider-active .video-react-menu-content,


### PR DESCRIPTION
In this PR, I make some modifications in order to style the volume slider to our own specifications. 

1) I enable `VolumeMenuButton` to accept children. I added a function for "default children", so that if there are no children passed to `VolumeMenuButton`, we see default behavior. I utilize the function `mergeAndSortChildren` to have the children passed receive the props for default children.
2) I export `VolumeBar` from `video-react`
3) I make some modifications to the `.scss` files so that I could style the volume slider in Angelou.
4) For kicks, I enabled 15-second replay.