### PR TITLE
Allow the Seek Bar to Take in Custom GrandChildren

### DIFF
--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -191,8 +191,8 @@ export default class Slider extends Component {
     if (this.props.childrenToMerge) {
       const { className, childrenToMerge, ...parentProps } = this.props;
       childrenToRender = mergeAndSortChildren(
-        childrenToMerge,
         children,
+        childrenToMerge,
         parentProps
       );
     } else {

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import * as Dom from '../utils/dom';
+import { mergeAndSortChildren } from '../utils';
 
 const propTypes = {
   className: PropTypes.string,
@@ -20,7 +21,8 @@ const propTypes = {
   children: PropTypes.node,
   label: PropTypes.string,
   valuenow: PropTypes.string,
-  valuetext: PropTypes.string
+  valuetext: PropTypes.string,
+  childrenToMerge: PropTypes.node
 };
 
 export default class Slider extends Component {
@@ -183,9 +185,24 @@ export default class Slider extends Component {
   }
 
   renderChildren() {
+    const children = this.props.children;
+
+    let childrenToRender;
+    if (this.props.childrenToMerge) {
+      const { className, childrenToMerge, ...parentProps } = this.props;
+      childrenToRender = mergeAndSortChildren(
+        childrenToMerge,
+        children,
+        parentProps
+      );
+    } else {
+      childrenToRender = children;
+    }
+
     const progress = this.getProgress();
     const percentage = `${(progress * 100).toFixed(2)}%`;
-    return React.Children.map(this.props.children, child =>
+
+    return React.Children.map(childrenToRender, child =>
       React.cloneElement(child, { progress, percentage })
     );
   }

--- a/src/components/control-bar/ProgressControl.js
+++ b/src/components/control-bar/ProgressControl.js
@@ -3,9 +3,11 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 
 import * as Dom from '../../utils/dom';
+import { mergeAndSortChildren } from '../../utils';
 import SeekBar from './SeekBar';
 
 const propTypes = {
+  children: PropTypes.node,
   player: PropTypes.object,
   className: PropTypes.string
 };
@@ -43,8 +45,28 @@ export default class ProgressControl extends Component {
     });
   }
 
+  getDefaultChildren() {
+    return [
+      <SeekBar
+        mouseTime={this.state.mouseTime}
+        ref={c => {
+          this.seekBar = c;
+        }}
+        {...this.props}
+      />
+    ];
+  }
+
+  getChildren() {
+    const children = React.Children.toArray(this.props.children);
+    const defaultChildren = this.getDefaultChildren();
+    const { className, ...parentProps } = this.props; // remove className
+    return mergeAndSortChildren(defaultChildren, children, parentProps);
+  }
+
   render() {
     const { className } = this.props;
+    const children = this.getChildren();
     return (
       <div
         onMouseMove={this.handleMouseMoveThrottle}
@@ -53,13 +75,7 @@ export default class ProgressControl extends Component {
           className
         )}
       >
-        <SeekBar
-          mouseTime={this.state.mouseTime}
-          ref={c => {
-            this.seekBar = c;
-          }}
-          {...this.props}
-        />
+        {children}
       </div>
     );
   }

--- a/src/components/control-bar/SeekBar.js
+++ b/src/components/control-bar/SeekBar.js
@@ -9,6 +9,7 @@ import MouseTimeDisplay from './MouseTimeDisplay';
 import { formatTime } from '../../utils';
 
 const propTypes = {
+  children: PropTypes.node,
   player: PropTypes.object,
   mouseTime: PropTypes.object,
   actions: PropTypes.object,
@@ -27,6 +28,7 @@ export default class SeekBar extends Component {
     this.handleMouseDown = this.handleMouseDown.bind(this);
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleMouseUp = this.handleMouseUp.bind(this);
+    this.getDefaultChildren = this.getDefaultChildren.bind(this);
   }
 
   componentDidMount() {}
@@ -83,12 +85,35 @@ export default class SeekBar extends Component {
     actions.replay(5);
   }
 
-  render() {
+  getDefaultChildren() {
     const {
       player: { currentTime, seekingTime, duration, buffered },
       mouseTime
     } = this.props;
+
     const time = seekingTime || currentTime;
+
+    return [
+      <LoadProgressBar
+        buffered={buffered}
+        currentTime={time}
+        duration={duration}
+      />,
+      <MouseTimeDisplay duration={duration} mouseTime={mouseTime} />,
+      <PlayProgressBar currentTime={time} duration={duration} />
+    ];
+  }
+
+  render() {
+    const {
+      children,
+      player: { currentTime, seekingTime, duration, buffered },
+      mouseTime
+    } = this.props;
+    const time = seekingTime || currentTime;
+
+    const renderGrandchildren =
+      children && children.props && children.props.children;
 
     return (
       <Slider
@@ -108,14 +133,21 @@ export default class SeekBar extends Component {
         getPercent={this.getPercent}
         stepForward={this.stepForward}
         stepBack={this.stepBack}
+        childrenToMerge={this.getDefaultChildren()}
       >
-        <LoadProgressBar
-          buffered={buffered}
-          currentTime={time}
-          duration={duration}
-        />
-        <MouseTimeDisplay duration={duration} mouseTime={mouseTime} />
-        <PlayProgressBar currentTime={time} duration={duration} />
+        {renderGrandchildren ? (
+          children.props.children
+        ) : (
+          <>
+            <LoadProgressBar
+              buffered={buffered}
+              currentTime={time}
+              duration={duration}
+            />
+            <MouseTimeDisplay duration={duration} mouseTime={mouseTime} />
+            <PlayProgressBar currentTime={time} duration={duration} />
+          </>
+        )}
       </Slider>
     );
   }

--- a/src/components/control-bar/SeekBar.js
+++ b/src/components/control-bar/SeekBar.js
@@ -28,7 +28,6 @@ export default class SeekBar extends Component {
     this.handleMouseDown = this.handleMouseDown.bind(this);
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleMouseUp = this.handleMouseUp.bind(this);
-    this.getDefaultChildren = this.getDefaultChildren.bind(this);
   }
 
   componentDidMount() {}
@@ -85,25 +84,6 @@ export default class SeekBar extends Component {
     actions.replay(5);
   }
 
-  getDefaultChildren() {
-    const {
-      player: { currentTime, seekingTime, duration, buffered },
-      mouseTime
-    } = this.props;
-
-    const time = seekingTime || currentTime;
-
-    return [
-      <LoadProgressBar
-        buffered={buffered}
-        currentTime={time}
-        duration={duration}
-      />,
-      <MouseTimeDisplay duration={duration} mouseTime={mouseTime} />,
-      <PlayProgressBar currentTime={time} duration={duration} />
-    ];
-  }
-
   render() {
     const {
       children,
@@ -114,6 +94,8 @@ export default class SeekBar extends Component {
 
     const renderGrandchildren =
       children && children.props && children.props.children;
+
+    const childrenToMerge = renderGrandchildren ? children.props.children : [];
 
     return (
       <Slider
@@ -133,21 +115,15 @@ export default class SeekBar extends Component {
         getPercent={this.getPercent}
         stepForward={this.stepForward}
         stepBack={this.stepBack}
-        childrenToMerge={this.getDefaultChildren()}
+        childrenToMerge={childrenToMerge}
       >
-        {renderGrandchildren ? (
-          children.props.children
-        ) : (
-          <>
-            <LoadProgressBar
-              buffered={buffered}
-              currentTime={time}
-              duration={duration}
-            />
-            <MouseTimeDisplay duration={duration} mouseTime={mouseTime} />
-            <PlayProgressBar currentTime={time} duration={duration} />
-          </>
-        )}
+        <LoadProgressBar
+          buffered={buffered}
+          currentTime={time}
+          duration={duration}
+        />
+        <MouseTimeDisplay duration={duration} mouseTime={mouseTime} />
+        <PlayProgressBar currentTime={time} duration={duration} />
       </Slider>
     );
   }


### PR DESCRIPTION
This PR allows the `<ProgressControl />`, `<SeekBar />`, and  `<Slider />` components to take in custom great-grandchildren, grandchildren,  and children. 

`<ProgressControl />` is the parent of `<SeekBar />`, which is the parent of  `<Slider />`.

 In `<ProgressControl />`, I do a modification of the `mergeAndSortChildren` logic used in other parts of `video-react`. There is a `getDefaultChildren` function and a `getChildren` function that merges the props of the default children and the custom children, modeled after what is done in `<ControlBar />`.

In `<SeekBar />`, I do almost the same thing as in `<ProgressControl />`; however, I make sure to render the default grandchildren children in the event that there are grandchildren.

 In `<Slider />`, I do a modification of the `mergeAndSortChildren` logic used in other parts of `video-react` in `renderChildren()`, but the default children are passed in as props from `<SeekBar />`.

The challenge here is that `<Slider />` is a child of both `<SeekBar />` and `<VolumeBar />`, so I had to keep `<Slider />` as generic as possible.