### PR TITLE
Remove BigPlayButton from default children

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -128,7 +128,6 @@ export default class Player extends Component {
       <PosterImage key="poster-image" order={1.0} />,
       <LoadingSpinner key="loading-spinner" order={2.0} />,
       <Bezel key="bezel" order={3.0} />,
-      <BigPlayButton key="big-play-button" order={4.0} />,
       <ControlBar key="control-bar" order={5.0} />,
       <AudioDescription key="audio-description" order={6.0} />,
       <OptionsOverlay key="options-overlay" order={7.0} />,


### PR DESCRIPTION
Previously, the `<BigPlayButton />` was a default child within the Player, meaning no matter what, a big play button will always render, even when the player is playing an audio track instead of a video, and even when the player has no image. Removing it from the default children allows for more visual flexibility. In both instances of our Audio and Video player, we are manually passing down the BigPlayButton, so this change will not affect existing implementations.