### PR TITLE
Accommodate for both audio and video file types

### DIFF
--- a/src/__tests__/Video.spec.js
+++ b/src/__tests__/Video.spec.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Video from '../components/Video';
+import Media from '../components/Media';
 
 describe('Video', () => {
   it('should render with "video" tag', () => {
-    const wrapper = shallow(<Video actions={{}} player={{}} />);
+    const wrapper = shallow(<Media actions={{}} player={{}} type="video" />);
 
     expect(wrapper.type()).toBe('video');
   });
 
   it('should render with "video-react-video" class', () => {
-    const wrapper = shallow(<Video actions={{}} player={{}} />);
+    const wrapper = shallow(<Media actions={{}} player={{}} />);
     expect(wrapper.hasClass('video-react-video')).toBe(true);
   });
 });

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -591,7 +591,6 @@ export default class Media extends Component {
         loop={loop}
         playsInline={playsInline}
         autoPlay={autoPlay}
-        poster={poster}
         src={src}
         onLoadStart={this.handleLoadStart}
         onWaiting={this.handleWaiting}

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 
 import { isVideoChild, mediaProperties, throttle } from '../utils';
+import { MediaType } from './Player';
 
 const propTypes = {
   actions: PropTypes.object,
@@ -533,7 +534,7 @@ export default class Media extends Component {
       crossOrigin,
       videoId
     } = this.props;
-    if (type.toLowerCase() === 'video') {
+    if (type === MediaType.video) {
       return (
         <video
           className={classNames('video-react-video', this.props.className)}

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -624,9 +624,7 @@ export default class Media extends Component {
 
   render() {
     return (
-      <div className={classNames('video-react-video-container')}>
-        {this.renderMedia()}
-      </div>
+      <div className="video-react-video-container">{this.renderMedia()}</div>
     );
   }
 }

--- a/src/components/Media.js
+++ b/src/components/Media.js
@@ -45,7 +45,7 @@ const propTypes = {
   onResize: PropTypes.func
 };
 
-export default class Video extends Component {
+export default class Media extends Component {
   constructor(props) {
     super(props);
 
@@ -630,5 +630,5 @@ export default class Video extends Component {
   }
 }
 
-Video.propTypes = propTypes;
-Video.displayName = 'Video';
+Media.propTypes = propTypes;
+Media.displayName = 'Media';

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -18,6 +18,11 @@ import fullscreen from '../utils/fullscreen';
 import OptionsOverlay from './menu/OptionsOverlay';
 import AudioDescription from './menu/AudioDescription';
 
+export const MediaType = {
+  audio: 'AUDIO',
+  video: 'VIDEO'
+};
+
 const propTypes = {
   children: PropTypes.any,
 
@@ -34,7 +39,7 @@ const propTypes = {
   loop: PropTypes.bool,
   autoPlay: PropTypes.bool,
   src: PropTypes.string,
-  type: PropTypes.oneOf(['audio', 'video']),
+  type: PropTypes.oneOf(Object.values(MediaType)),
   poster: PropTypes.string,
   preload: PropTypes.oneOf(['auto', 'metadata', 'none']),
 
@@ -72,7 +77,7 @@ const defaultProps = {
   aspectRatio: 'auto'
 };
 
-export default class Player extends Component {
+export class Player extends Component {
   constructor(props) {
     super(props);
 
@@ -443,3 +448,4 @@ Player.contextTypes = { store: PropTypes.object };
 Player.propTypes = propTypes;
 Player.defaultProps = defaultProps;
 Player.displayName = 'Player';
+Player.mediaType = MediaType;

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -128,7 +128,6 @@ export default class Player extends Component {
       <PosterImage key="poster-image" order={1.0} />,
       <LoadingSpinner key="loading-spinner" order={2.0} />,
       <Bezel key="bezel" order={3.0} />,
-      <BigPlayButton key="big-play-button" order={4.0} />,
       <ControlBar key="control-bar" order={5.0} />,
       <AudioDescription key="audio-description" order={6.0} />,
       <OptionsOverlay key="options-overlay" order={7.0} />,

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -4,10 +4,8 @@ import classNames from 'classnames';
 
 import Manager from '../Manager';
 
-import BigPlayButton from './BigPlayButton';
 import LoadingSpinner from './LoadingSpinner';
 import PosterImage from './PosterImage';
-// import Video from './Video';
 import Media from './Media';
 import Bezel from './Bezel';
 import Shortcut from './Shortcut';

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -35,7 +35,7 @@ const propTypes = {
   loop: PropTypes.bool,
   autoPlay: PropTypes.bool,
   src: PropTypes.string,
-  type: PropTypes.string,
+  type: PropTypes.oneOf(['audio', 'video']),
   poster: PropTypes.string,
   preload: PropTypes.oneOf(['auto', 'metadata', 'none']),
 

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -7,7 +7,8 @@ import Manager from '../Manager';
 import BigPlayButton from './BigPlayButton';
 import LoadingSpinner from './LoadingSpinner';
 import PosterImage from './PosterImage';
-import Video from './Video';
+// import Video from './Video';
+import Media from './Media';
 import Bezel from './Bezel';
 import Shortcut from './Shortcut';
 import ControlBar from './control-bar/ControlBar';
@@ -116,7 +117,7 @@ export default class Player extends Component {
 
   getDefaultChildren(originalChildren) {
     return [
-      <Video
+      <Media
         ref={c => {
           this.video = c;
           this.manager.video = this.video;
@@ -125,7 +126,7 @@ export default class Player extends Component {
         order={0.0}
       >
         {originalChildren}
-      </Video>,
+      </Media>,
       <PosterImage key="poster-image" order={1.0} />,
       <LoadingSpinner key="loading-spinner" order={2.0} />,
       <Bezel key="bezel" order={3.0} />,

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -35,6 +35,7 @@ const propTypes = {
   loop: PropTypes.bool,
   autoPlay: PropTypes.bool,
   src: PropTypes.string,
+  type: PropTypes.string,
   poster: PropTypes.string,
   preload: PropTypes.oneOf(['auto', 'metadata', 'none']),
 

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -14,6 +14,7 @@ const propTypes = {
   autoPlay: PropTypes.bool,
   playsInline: PropTypes.bool,
   src: PropTypes.string,
+  type: PropTypes.string,
   poster: PropTypes.string,
   className: PropTypes.string,
   preload: PropTypes.oneOf(['auto', 'metadata', 'none']),
@@ -57,6 +58,7 @@ export default class Video extends Component {
     this.toggleFullscreen = this.toggleFullscreen.bind(this);
     this.getProperties = this.getProperties.bind(this);
     this.renderChildren = this.renderChildren.bind(this);
+    this.renderMedia = this.renderMedia.bind(this);
     this.handleLoadStart = this.handleLoadStart.bind(this);
     this.handleCanPlay = this.handleCanPlay.bind(this);
     this.handleCanPlayThrough = this.handleCanPlayThrough.bind(this);
@@ -518,21 +520,21 @@ export default class Video extends Component {
       });
   }
 
-  render() {
+  renderMedia() {
     const {
       loop,
       poster,
       preload,
       src,
+      type,
       autoPlay,
       playsInline,
       muted,
       crossOrigin,
       videoId
     } = this.props;
-
-    return (
-      <div className={classNames('video-react-video-container')}>
+    if (type.toLowerCase() === 'video') {
+      return (
         <video
           className={classNames('video-react-video', this.props.className)}
           id={videoId}
@@ -573,6 +575,56 @@ export default class Video extends Component {
         >
           {this.renderChildren()}
         </video>
+      );
+    }
+    return (
+      <audio
+        className={classNames('video-react-video', this.props.className)}
+        id={videoId}
+        crossOrigin={crossOrigin}
+        ref={c => {
+          this.video = c;
+        }}
+        muted={muted}
+        preload={preload}
+        loop={loop}
+        playsInline={playsInline}
+        autoPlay={autoPlay}
+        poster={poster}
+        src={src}
+        onLoadStart={this.handleLoadStart}
+        onWaiting={this.handleWaiting}
+        onCanPlay={this.handleCanPlay}
+        onCanPlayThrough={this.handleCanPlayThrough}
+        onPlaying={this.handlePlaying}
+        onEnded={this.handleEnded}
+        onSeeking={this.handleSeeking}
+        onSeeked={this.handleSeeked}
+        onPlay={this.handlePlay}
+        onPause={this.handlePause}
+        onProgress={this.handleProgress}
+        onDurationChange={this.handleDurationChange}
+        onError={this.handleError}
+        onSuspend={this.handleSuspend}
+        onAbort={this.handleAbort}
+        onEmptied={this.handleEmptied}
+        onStalled={this.handleStalled}
+        onLoadedMetadata={this.handleLoadedMetaData}
+        onLoadedData={this.handleLoadedData}
+        onTimeUpdate={this.handleTimeUpdate}
+        onRateChange={this.handleRateChange}
+        onVolumeChange={this.handleVolumeChange}
+        tabIndex="-1"
+      >
+        {this.renderChildren()}
+      </audio>
+    );
+  }
+
+  render() {
+    return (
+      <div className={classNames('video-react-video-container')}>
+        {this.renderMedia()}
       </div>
     );
   }

--- a/src/components/control-bar/PlayToggle.js
+++ b/src/components/control-bar/PlayToggle.js
@@ -24,8 +24,8 @@ export default class PlayToggle extends Component {
   }
 
   render() {
-    const { player, className, type } = this.props;
-    const controlText = player.paused ? `Play ${type}` : `Pause ${type}`;
+    const { player, className } = this.props;
+    const controlText = player.paused ? `Play` : `Pause`;
 
     return (
       <button

--- a/src/components/control-bar/PlayToggle.js
+++ b/src/components/control-bar/PlayToggle.js
@@ -24,8 +24,8 @@ export default class PlayToggle extends Component {
   }
 
   render() {
-    const { player, className } = this.props;
-    const controlText = player.paused ? 'Play Video' : 'Pause Video';
+    const { player, className, type } = this.props;
+    const controlText = player.paused ? `Play ${type}` : `Pause ${type}`;
 
     return (
       <button

--- a/src/components/control-bar/SeekBar.js
+++ b/src/components/control-bar/SeekBar.js
@@ -88,7 +88,8 @@ export default class SeekBar extends Component {
     const {
       children,
       player: { currentTime, seekingTime, duration, buffered },
-      mouseTime
+      mouseTime,
+      type
     } = this.props;
     const time = seekingTime || currentTime;
 
@@ -96,13 +97,14 @@ export default class SeekBar extends Component {
       children && children.props && children.props.children;
 
     const childrenToMerge = renderGrandchildren ? children.props.children : [];
+    const label = `${type} progress bar`;
 
     return (
       <Slider
         ref={input => {
           this.slider = input;
         }}
-        label="video progress bar"
+        label={label}
         className={classNames(
           'video-react-progress-holder',
           this.props.className

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Player from './components/Player';
+import { Player } from './components/Player';
 import Media from './components/Media';
 import BigPlayButton from './components/BigPlayButton';
 import LoadingSpinner from './components/LoadingSpinner';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Player from './components/Player';
-import Video from './components/Video';
+import Media from './components/Media';
 import BigPlayButton from './components/BigPlayButton';
 import LoadingSpinner from './components/LoadingSpinner';
 import PosterImage from './components/PosterImage';
@@ -39,7 +39,7 @@ import { playerReducer, operationReducer } from './reducers';
 
 export {
   Player,
-  Video,
+  Media,
   BigPlayButton,
   LoadingSpinner,
   PosterImage,


### PR DESCRIPTION
- Rename the `Video` component to a more generic `Media`
- Render an underlying <audio> element when the type of file is specified as audio
- Render an underlying <video> element when the type of file is specified as video (already included from original default functionality)
- Where possible, change labels of elements to make VoiceOver announce the proper type